### PR TITLE
Initialize data variable

### DIFF
--- a/gcptree/cache.py
+++ b/gcptree/cache.py
@@ -7,6 +7,7 @@ class Cache():
   TIMESTAMP_FORMAT = "%Y-%m-%d-%H-%M"
 
   def __init__(self):
+    self.data = {}
     self.filename = os.path.join(gettempdir(), "gcptree-cache.json")
     if os.path.exists(self.filename):
       with open(self.filename, 'r') as f:


### PR DESCRIPTION
I was receiving this error on first run - 

```
Traceback (most recent call last):
  File "/usr/local/bin/gcptree", line 5, in <module>
    Cli().run()
  File "/usr/local/lib/python3.9/site-packages/gcptree/cli.py", line 55, in run
    tree = self.build_tree()
  File "/usr/local/lib/python3.9/site-packages/gcptree/cli.py", line 28, in build_tree
    if t.cache.is_empty():
  File "/usr/local/lib/python3.9/site-packages/gcptree/cache.py", line 23, in is_empty
    return len(self.data) == 0
AttributeError: 'Cache' object has no attribute 'data'
```

Added cache data initialization to build the first cache file.