### PR TITLE
feat: Use CAI instead of CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,4 @@ optional arguments:
 The minimum role you'll need **at the organization level** is:
 
 * `roles/browser`
-
-The actual permissions needed (in case you want a custom role) are:
-
-* `resourcemanager.projects.get`
-* `resourcemanager.projects.list`
-* `resourcemanager.folders.get`
-* `resourcemanager.organizations.get`
+* `roles/cloudasset.viewer`

--- a/gcptree/cache.py
+++ b/gcptree/cache.py
@@ -18,6 +18,9 @@ class Cache():
         self.data = self.updated_data(data)
         
   def updated_data(self, data):
+    # A v1 cache (using CRM instead of CAI) is not compatible, so we simply overwrite it
+    if '_v2' not in data:
+      return {}
     if '_ttl' in data:
       self.ttl_hours = data['_ttl']
     previous_timestamp = datetime.strptime(data['_timestamp'], self.TIMESTAMP_FORMAT)
@@ -44,6 +47,7 @@ class Cache():
   def write(self):
     self.data['_timestamp'] = self.timestamp()
     self.data['_ttl'] = self.ttl_hours
+    self.data['_v2'] = True
     with open(self.filename, 'w') as f:
       json.dump(self.data, f)
 
@@ -51,4 +55,23 @@ class Cache():
     hours = 'an hour'
     if self.ttl_hours > 1:
       hours = "{} hours". format(self.ttl_hours)
-    return 'Fetching GCP Resources, this may take a while (these results will be cached for {} in {})... '.format(hours, self.filename)
+    return 'INFO: Fetching GCP Resources, this may take a while (these results will be cached for {} in {})... '.format(hours, self.filename)
+
+class NoCache():
+  def is_empty(self):
+    return True
+
+  def has(self, key):
+    return False
+
+  def get(self, key):
+    return None
+
+  def add(self, key, value):
+    return None
+
+  def write(self):
+    pass
+
+  def message(self):
+    return 'INFO: Cache will not be used.'

--- a/gcptree/cli.py
+++ b/gcptree/cli.py
@@ -1,9 +1,10 @@
 import argparse
 import json
 import sys
+from googleapiclient.errors import HttpError
 from colorama import init, Fore, Style
 from .tree import Tree
-from .cache import Cache
+from .cache import Cache, NoCache
 
 LEAF      = "└── "
 LEAF_PLUS = "├── "
@@ -21,6 +22,9 @@ class Cli:
     parser.add_argument('--full-resource', action='store_const',
                         const=True, default = False,
                         help='API-parsable nodes where org and folder resource names are not resolved, i.e org/123 instead of example.com')
+    parser.add_argument('--no-cache', action='store_const',
+                        const=True, default = False,
+                        help='If set, cache will not be used.')
     parser.add_argument('--cache-ttl', default=1, type=int,
                         help='Number of hours to keep the cache, default is 1.')
 
@@ -28,10 +32,17 @@ class Cli:
   
   def build_tree(self):
     cache = Cache(ttl_hours=self.args.cache_ttl)
+    if self.args.no_cache:
+      cache = NoCache()
     if cache.is_empty():
       print(cache.message(), file=sys.stderr)
     t = Tree(self.args.org_id[0], full_resource=self.args.full_resource, cache_inst=cache)
-    return t.build()
+    try:
+      return t.build()
+    except HttpError as e:
+      if e.resp.status == 403:
+        print(self.permission_help())
+        sys.exit(1)
   
   def is_project(self, obj):
     return len(obj) > 0 and 'projectId' in obj
@@ -42,7 +53,7 @@ class Cli:
       lchar, schar = (LEAF, SPACE) if i == len(nodes) - 1 else (LEAF_PLUS, BAR_SPACE)
       if self.is_project(tree[node]):
         formatted = node
-        if tree[node]['lifecycleState'] != 'ACTIVE':
+        if tree[node]['state'] != 'ACTIVE':
           formatted = Style.DIM + node + Style.RESET_ALL
         print(prefix + lchar + formatted)
       else:
@@ -62,3 +73,14 @@ class Cli:
       self.print_tree(tree)
     else:
       print("Unsupported format")
+
+  def permission_help(self):
+    msg = """
+GCP Permission Error. Make sure you have the following roles at the org level:
+- roles/browser
+- roles/cloudasset.viewer
+
+If you're using a service account, ensure that the correct key file path is
+referenced in the environment variable: GOOGLE_APPLICATION_CREDENTIALS
+"""
+    return Style.BRIGHT + Fore.RED + msg + Style.RESET_ALL

--- a/gcptree/cli.py
+++ b/gcptree/cli.py
@@ -6,15 +6,18 @@ from colorama import init, Fore, Style
 from .tree import Tree
 from .cache import Cache, NoCache
 
-LEAF      = "└── "
-LEAF_PLUS = "├── "
-BAR_SPACE = "│   "
-SPACE     = "    "
+VERSION = "0.2.0"
 
 class Cli:
+  LEAF      = "└── "
+  LEAF_PLUS = "├── "
+  BAR_SPACE = "│   "
+  SPACE     = "    "
+
   def __init__(self):
     init()
-    parser = argparse.ArgumentParser(description='Print out a GCP org heirarchy', prog="gcptree")
+
+    parser = argparse.ArgumentParser(description='Print out a GCP org heirarchy', prog="gcptree", epilog="Version: {}".format(VERSION))
     parser.add_argument('org_id', nargs=1, 
                         help='GCP Organization ID')
     parser.add_argument('--format', default="text",
@@ -50,7 +53,7 @@ class Cli:
   def walk(self, tree, prefix=""):
     nodes = sorted(tree.keys())
     for i, node in enumerate(nodes):
-      lchar, schar = (LEAF, SPACE) if i == len(nodes) - 1 else (LEAF_PLUS, BAR_SPACE)
+      lchar, schar = (self.LEAF, self.SPACE) if i == len(nodes) - 1 else (self.LEAF_PLUS, self.BAR_SPACE)
       if self.is_project(tree[node]):
         formatted = node
         if tree[node]['state'] != 'ACTIVE':

--- a/gcptree/test_cache.py
+++ b/gcptree/test_cache.py
@@ -5,23 +5,23 @@ from .cache import Cache
 def test_cache_loaded():
   inst = Cache(cache_file="test.json")
   a_few_minutes_ago = datetime.now() - timedelta(minutes=15)
-  data = {"_timestamp": a_few_minutes_ago.strftime(inst.TIMESTAMP_FORMAT), "key":"value"}
+  data = {"_timestamp": a_few_minutes_ago.strftime(inst.TIMESTAMP_FORMAT), "_v2": True}
   assert len(inst.updated_data(data)) > 0
 
 def test_cache_busted():
   inst = Cache(cache_file="test.json")
   over_an_hour_ago = datetime.now() - timedelta(minutes=90)
-  data = {"_timestamp": over_an_hour_ago.strftime(inst.TIMESTAMP_FORMAT), "key":"value"}
+  data = {"_timestamp": over_an_hour_ago.strftime(inst.TIMESTAMP_FORMAT), "_v2": True}
   assert len(inst.updated_data(data)) == 0
 
 def test_cache_loaded_2():
   inst = Cache(cache_file="test.json")
   a_few_minutes_ago = datetime.now() - timedelta(minutes=90)
-  data = {"_timestamp": a_few_minutes_ago.strftime(inst.TIMESTAMP_FORMAT), "_ttl":2}
+  data = {"_timestamp": a_few_minutes_ago.strftime(inst.TIMESTAMP_FORMAT), "_ttl":2, "_v2": True}
   assert len(inst.updated_data(data)) > 0
 
 def test_cache_busted_2():
   inst = Cache(cache_file="test.json")
   over_an_hour_ago = datetime.now() - timedelta(minutes=150)
-  data = {"_timestamp": over_an_hour_ago.strftime(inst.TIMESTAMP_FORMAT), "_ttl":2}
+  data = {"_timestamp": over_an_hour_ago.strftime(inst.TIMESTAMP_FORMAT), "_ttl":2, "_v2": True}
   assert len(inst.updated_data(data)) == 0

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,21 @@
 from setuptools import setup
+import re
 # read the contents of your README file
 from os import path
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
   long_description = f.read()
 
+version = None
+with open(path.join(this_directory, 'gcptree/cli.py'), encoding='utf-8') as f:
+  for line in f.readlines():
+    match = re.search("VERSION = \"(.*?)\"$", line)
+    if match:
+      version = match[1]
+      break
+
 setup(name='gcptree',
-      version='0.2.0',
+      version=version,
       description='List your GCP Org heirachy as a tree in JSON or Text',
       url='http://github.com/onetwopunch/gcptree',
       scripts=['bin/gcptree'],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
   long_description = f.read()
 
 setup(name='gcptree',
-      version='0.1.5',
+      version='0.2.0',
       description='List your GCP Org heirachy as a tree in JSON or Text',
       url='http://github.com/onetwopunch/gcptree',
       scripts=['bin/gcptree'],


### PR DESCRIPTION
Fixes: #4

Note that project name has changed to support CRM v3, which means
format is now projects/NUMBER instead of projects/ID.

Thanks to `u/rosmo` on Reddit for pointing out the an assets list
feature exists :)

This feature has a number of improvements:
* Performance boost due to less round trip API calls thanks to CAI
* The `--no-cache` option to manually bust the cache
* Helpful error message and auto-cache upgrade logic to help migration
* From now on the pip version will appear in the help message